### PR TITLE
Remove lodash dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
   ],
   "homepage": "https://github.com/buildo/react-placeholder",
   "typings": "lib/index.d.ts",
-  "dependencies": {
-    "lodash.omit": "^4.5.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.24.0",

--- a/src/ReactPlaceholder.js
+++ b/src/ReactPlaceholder.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import omit from 'lodash.omit';
 import * as placeholders from './placeholders';
 
 export default class ReactPlaceholder extends React.Component {
@@ -34,16 +33,17 @@ export default class ReactPlaceholder extends React.Component {
   )
 
   getFiller = () => {
-    const { type, customPlaceholder } = this.props;
+    // eslint-disable-next-line no-unused-vars
+    const { type, customPlaceholder, children, ready, firstLaunchOnly, ...rest } = this.props;
+
     if (customPlaceholder) {
       return customPlaceholder;
     }
 
     const Placeholder = placeholders[type];
-    const props = omit(this.props, ['children', 'ready', 'firstLaunchOnly', 'type']);
 
-    return <Placeholder {...props} />;
-  }
+    return <Placeholder {...rest} />;
+  };
 
   render() {
     return this.isReady() ? this.props.children : this.getFiller();
@@ -56,5 +56,4 @@ export default class ReactPlaceholder extends React.Component {
       });
     }
   }
-
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2988,10 +2988,6 @@ lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"


### PR DESCRIPTION
There is no needs for lodash.omit with ES6 and babel usage. lodash.omit adds at least 1KB in to final build.
Also, i reformat lifecycle hooks to be at top level in `ReactPlaceholder` class
