### PR TITLE
Filter undefined class names

### DIFF
--- a/src/placeholders/MediaBlock.js
+++ b/src/placeholders/MediaBlock.js
@@ -15,8 +15,11 @@ export default class MediaBlock extends React.Component {
 
   render() {
     const { className, style, color, rows } = this.props;
+
+    const classes = ['media-block', className].filter(c => c).join(' ');
+
     return (
-      <div className={`media-block ${className}`} style={{ ...style, display: 'flex' }}>
+      <div className={classes} style={{ ...style, display: 'flex' }}>
         <RoundShape
           color={color}
           style={{ minHeight: 55, width: 55, minWidth: 55, marginRight: 10 }}

--- a/src/placeholders/RectShape.js
+++ b/src/placeholders/RectShape.js
@@ -19,8 +19,10 @@ export default class RectShape extends React.Component {
       marginRight: 10
     };
 
+    const classes = ['rect-shape', className].filter(c => c).join(' ');
+
     return (
-      <div className={`rect-shape ${className}`} style={{ ...defaultStyle, ...style }}/>
+      <div className={classes} style={{ ...defaultStyle, ...style }}/>
     );
   }
 

--- a/src/placeholders/RoundShape.js
+++ b/src/placeholders/RoundShape.js
@@ -19,8 +19,10 @@ export default class RoundShape extends React.Component {
       height: '100%'
     };
 
+    const classes = ['round-shape', className].filter(c => c).join(' ');
+
     return (
-      <div className={`round-shape ${className}`} style={{ ...defaultStyles, ...style }}/>
+      <div className={classes} style={{ ...defaultStyles, ...style }}/>
     );
   }
 

--- a/src/placeholders/TextBlock.js
+++ b/src/placeholders/TextBlock.js
@@ -42,8 +42,10 @@ export default class TextBlock extends React.Component {
   render() {
     const { style, className } = this.props;
 
+    const classes = ['text-block', className].filter(c => c).join(' ');
+
     return (
-      <div className={`text-block ${className}`} style={{ ...style, width: '100%' }}>
+      <div className={classes} style={{ ...style, width: '100%' }}>
         {this.getRows()}
       </div>
     );

--- a/src/placeholders/TextRow.js
+++ b/src/placeholders/TextRow.js
@@ -28,9 +28,11 @@ export default class TextRow extends React.Component {
       marginTop: lineSpacing
     };
 
+    const classes = ['text-row', className].filter(c => c).join(' ');
+
     return (
       <div
-        className={`text-row ${className}`}
+        className={classes}
         style={{ ...defaultStyles, ...style }}
       />
     );


### PR DESCRIPTION
Just following up from #24, this fixes an issue where an `undefined` class would be set on elements. Let me know if you're happy with this implementation or if there's another way you'd like to go about it.

Also, thanks for your work on this library - only discovered it an hour or so ago but it's very handy.