### PR TITLE
#34: Animations not working with custom placeholders. (closes #34)

### DIFF
--- a/src/ReactPlaceholder.js
+++ b/src/ReactPlaceholder.js
@@ -40,13 +40,19 @@ export default class ReactPlaceholder extends React.Component {
       type, customPlaceholder, showLoadingAnimation, ...rest
     } = this.props;
 
-    if (customPlaceholder) {
-      return customPlaceholder;
-    }
-
     const classes = showLoadingAnimation ?
       ['show-loading-animation', className].filter(c => c).join(' ') :
       className;
+
+    if (customPlaceholder && React.isValidElement(customPlaceholder)) {
+      const mergedCustomClasses = [
+        customPlaceholder.props.className,
+        classes
+      ].filter(c => c).join(' ');
+      return React.cloneElement(customPlaceholder, { className: mergedCustomClasses });
+    } else if (customPlaceholder) {
+      return customPlaceholder;
+    }
 
     const Placeholder = placeholders[type];
 


### PR DESCRIPTION
Closes #34

## Test Plan

### tests performed
temporarily modified the example to use one of our built-in placeholder:
[![https://gyazo.com/e17321a7312dcbbffed93d77eb700e7b](https://i.gyazo.com/e17321a7312dcbbffed93d77eb700e7b.gif)](https://gyazo.com/e17321a7312dcbbffed93d77eb700e7b)

the animation works 🎉 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
