### PR TITLE
add delay prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ coverage
 npm-debug.log
 lib
 .eslintcache
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 npm-debug.log
 lib
 .eslintcache
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ children:             PropTypes.oneOfType([
                          PropTypes.element
                       ]).isRequired,
 ready:                PropTypes.bool.isRequired,
+delay:                PropTypes.number,
 firstLaunchOnly:      PropTypes.bool,
 showLoadingAnimation: PropTypes.bool,
 type:                 PropTypes.oneOf(['text', 'media', 'textRow', 'rect', 'round']),
@@ -72,6 +73,11 @@ const awesomePlaceholder (
   <MyComponent />
 </ReactPlaceholder>
 ```
+
+### Delay
+You can pass an optional `delay` prop which specifies the time (in milliseconds) `react-placeholder` should wait before displaying the placeholder element. This is useful if you want to show a placeholder for slower connections while avoiding a brief "flash" on faster connections.
+
+Note that this delay will __not__ affect the initial render, only subsequent "ready" state changes. Setting the `firsLaunchOnly` prop to `true` will also disable this feature.
 
 ### Animation
 `react-placeholder` already comes with one default pulse animation to better tell the user that the page is loading.

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -14,6 +14,7 @@ import '../src/reactPlaceholder.scss';
 class Example extends React.Component {
 
   state = {
+    delay: 1000,
     ready: false,
     readyCustom: false,
     readyFirstLaunch: false,
@@ -170,6 +171,34 @@ class Example extends React.Component {
             color='#E0E0E0'
             className='my-text-block'
             firstLaunchOnly
+          >
+            {realComponent}
+          </ReactPlaceholder>
+        </div>
+
+        <h1>Using ReactPlaceholder with a delay</h1>
+        <button onClick={this.toggleReadyFirstLaunch} style={buttonStyle}>
+          {this.state.readyFirstLaunch ? 'set loading' : 'set ready'}
+        </button>
+        <p>Will show filler only after specified delay</p>
+        <div className='ui input'>
+          <span style={{ lineHeight: '40px' }}>
+            delay (ms):
+          </span>
+          <input
+            type='number'
+            value={this.state.delay}
+            onChange={this.onChange('delay')}
+            style={{ width: 80, marginLeft: 5 }}
+          />
+        </div>
+        <div className='ui segment'>
+          <ReactPlaceholder
+            ready={this.state.readyFirstLaunch}
+            delay={this.state.delay}
+            rows={4}
+            color='#E0E0E0'
+            className='my-text-block'
           >
             {realComponent}
           </ReactPlaceholder>

--- a/src/ReactPlaceholder.js
+++ b/src/ReactPlaceholder.js
@@ -9,6 +9,7 @@ export default class ReactPlaceholder extends React.Component {
       PropTypes.node,
       PropTypes.element
     ]).isRequired,
+    delay: PropTypes.number,
     ready: PropTypes.bool.isRequired,
     firstLaunchOnly: PropTypes.bool,
     type: PropTypes.oneOf(['text', 'media', 'textRow', 'rect', 'round']),
@@ -22,6 +23,7 @@ export default class ReactPlaceholder extends React.Component {
   }
 
   static defaultProps = {
+    delay: 0,
     type: 'text',
     color: '#CDCDCD'
   }
@@ -29,10 +31,6 @@ export default class ReactPlaceholder extends React.Component {
   state = {
     ready: this.props.ready
   }
-
-  isReady = () => (
-    this.props.firstLaunchOnly ? this.state.ready : this.props.ready
-  )
 
   getFiller = () => {
     const {
@@ -59,15 +57,29 @@ export default class ReactPlaceholder extends React.Component {
     return <Placeholder {...rest} className={classes} />;
   };
 
+  setNotReady = () => {
+    this.timeout = setTimeout(() => {
+      this.setState({ ready: false });
+    }, this.props.delay);
+  }
+
+  setReady = () => {
+    clearTimeout(this.timeout);
+
+    if (!this.state.ready) {
+      this.setState({ ready: true });
+    }
+  }
+
   render() {
-    return this.isReady() ? this.props.children : this.getFiller();
+    return this.state.ready ? this.props.children : this.getFiller();
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.state.ready) {
-      this.setState({
-        ready: nextProps.ready
-      });
+    if (!this.props.firstLaunchOnly && this.state.ready && !nextProps.ready) {
+      this.setNotReady();
+    } else if (nextProps.ready) {
+      this.setReady();
     }
   }
 }

--- a/src/ReactPlaceholder.js
+++ b/src/ReactPlaceholder.js
@@ -58,13 +58,21 @@ export default class ReactPlaceholder extends React.Component {
   };
 
   setNotReady = () => {
-    this.timeout = setTimeout(() => {
+    const { delay } = this.props;
+
+    if (delay > 0) {
+      this.timeout = setTimeout(() => {
+        this.setState({ ready: false });
+      }, delay);
+    } else {
       this.setState({ ready: false });
-    }, this.props.delay);
+    }
   }
 
   setReady = () => {
-    clearTimeout(this.timeout);
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
 
     if (!this.state.ready) {
       this.setState({ ready: true });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ interface ReactPlaceholderProps {
   // FIXME: children is marked as optional because of https://github.com/Microsoft/TypeScript/issues/8588
   children?: ReactChild,
   ready: boolean,
+  delay: number,
   firstLaunchOnly?: boolean,
   type?: 'text' |  'media' | 'textRow' | 'rect' | 'round',
   rows?: number,

--- a/tests/ReactPlaceholder.test.js
+++ b/tests/ReactPlaceholder.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactPlaceholder from '../src/ReactPlaceholder';
 import { shallow } from 'enzyme';
 
+jest.useFakeTimers();
+
 describe('ReactPlaceholder', () => {
 
   it('renders the placeholder when the content is not ready', () => {
@@ -12,6 +14,26 @@ describe('ReactPlaceholder', () => {
       </ReactPlaceholder>
     );
     expect(tree.contains(content)).toBe(false);
+    expect(tree.getNodes()).toMatchSnapshot();
+  });
+
+  it('renders the placeholder only after the specified delay', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder
+        ready
+        type='text'
+        rows={2}
+        delay={10000}
+      >
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(expect(tree.contains(content)).toBe(true));
+    tree.setProps({ ready: false });
+    expect(expect(tree.contains(content)).toBe(true));
+    jest.runAllTimers();
+    expect(expect(tree.contains(content)).toBe(false));
     expect(tree.getNodes()).toMatchSnapshot();
   });
 

--- a/tests/__snapshots__/ReactPlaceholder.test.js.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.js.snap
@@ -8,11 +8,23 @@ Array [
 ]
 `;
 
+exports[`ReactPlaceholder renders the placeholder only after the specified delay 1`] = `
+Array [
+  <TextBlock
+    className={undefined}
+    color="#CDCDCD"
+    delay={10000}
+    rows={2}
+/>,
+]
+`;
+
 exports[`ReactPlaceholder renders the placeholder when the content is not ready 1`] = `
 Array [
   <TextBlock
     className={undefined}
     color="#CDCDCD"
+    delay={0}
     rows={2}
 />,
 ]


### PR DESCRIPTION
Closes #49 

Thanks for this great component. This PR adds a `delay` prop that lets you specify how long to wait before displaying the placeholder component (after the initial render) when the `ready` state changes from `true` to `false`.

This is intended to prevent the "flash" that can happen on faster connections when the placeholder component is shown for only a brief moment, while still showing it for slower connections.