### PR TITLE
allow react 16 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack-dev-server": "^1"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15",
-    "react-dom": "^0.14 || ^15"
+    "react": "^0.14 || ^15 || ^16",
+    "react-dom": "^0.14 || ^15 || ^16"
   }
 }


### PR DESCRIPTION
This PR  is to address issue #46, adding support for React 16 as a peer dependency.