### PR TITLE
#65: Array.apply not supported in ie8 in TextBlock even if I add the polyfill (closes #65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-placeholder",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A React component to easily replicate your page with nice placeholders while the content is loading",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-placeholder",
-  "version": "1.0.11",
+  "version": "1.0.10",
   "description": "A React component to easily replicate your page with nice placeholders while the content is loading",
   "main": "lib",
   "scripts": {

--- a/src/placeholders/TextBlock.js
+++ b/src/placeholders/TextBlock.js
@@ -32,7 +32,7 @@ export default class TextBlock extends React.Component {
 
   getRows = () => {
     const { rows, lineSpacing } = this.props;
-    const range = Array.from({ length: rows }); // eslint-disable-line prefer-spread
+    const range = [...Array(rows)];
     return range.map((x, i) => (
       <TextRow
         style={this.getRowStyle(i)}

--- a/src/placeholders/TextBlock.js
+++ b/src/placeholders/TextBlock.js
@@ -32,7 +32,7 @@ export default class TextBlock extends React.Component {
 
   getRows = () => {
     const { rows, lineSpacing } = this.props;
-    const range = Array.apply(null, Array(rows)); // eslint-disable-line prefer-spread
+    const range = Array.from({ length: rows }); // eslint-disable-line prefer-spread
     return range.map((x, i) => (
       <TextRow
         style={this.getRowStyle(i)}


### PR DESCRIPTION
fix:Array.apply not support ie8 in TextBlock even if I'm add the polyfill