### PR TITLE
Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,21 @@ npm install --save react-placeholder
 
 ### Props
 
-```jsx
-children:             PropTypes.oneOfType([
-                         PropTypes.node,
-                         PropTypes.element
-                      ]).isRequired,
-ready:                PropTypes.bool.isRequired,
-delay:                PropTypes.number,
-firstLaunchOnly:      PropTypes.bool,
-showLoadingAnimation: PropTypes.bool,
-type:                 PropTypes.oneOf(['text', 'media', 'textRow', 'rect', 'round']),
-rows:                 PropTypes.number,
-color:                PropTypes.string,
-customPlaceholder:    PropTypes.oneOfType([
-                         PropTypes.node,
-                         PropTypes.element
-                      ])
+```tsx
+children:              ReactElement | null;
+ready:                 boolean;
+delay?:                number;
+firstLaunchOnly?:      boolean;
+showLoadingAnimation?: boolean;
+type?:                 'text' | 'media' | 'textRow' | 'rect' | 'round';
+rows?:                 number;
+color?:                string;
+customPlaceholder?:    ReactElement;
+className?:            string;
+style?:                CSSProperties;
 ```
+
+The default props will render a `text` placeholder with `3` rows and the color `#CDCDCD`.
 
 ### Customization
 If the built-in set of placeholders is not enough, you can pass you own through the prop **"customPlaceholder"**

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "typings": "lib",
   "dependencies": {},
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.1.1",
+    "@testing-library/react": "^9.4.0",
     "@types/enzyme": "^3.10.4",
     "@types/jest": "^24.0.23",
     "@types/lodash": "^4.14.149",

--- a/package.json
+++ b/package.json
@@ -34,15 +34,12 @@
   ],
   "homepage": "https://github.com/buildo/react-placeholder",
   "typings": "lib",
-  "dependencies": {
-    "prop-types": "^15.7.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/enzyme": "^3.10.4",
     "@types/jest": "^24.0.23",
     "@types/lodash": "^4.14.149",
     "@types/node": "12.12.17",
-    "@types/prop-types": "^15.7.3",
     "@types/react": "^16.9.16",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -35,40 +35,43 @@
   "homepage": "https://github.com/buildo/react-placeholder",
   "typings": "lib",
   "dependencies": {
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@types/enzyme": "2.8.6",
-    "@types/jest": "^22",
-    "@types/node": "9.6.4",
-    "@types/prop-types": "^15.5.2",
-    "@types/react": "^16.3.10",
-    "babel-loader": "^7.1.2",
+    "@types/enzyme": "^3.10.4",
+    "@types/jest": "^24.0.23",
+    "@types/lodash": "^4.14.149",
+    "@types/node": "12.12.17",
+    "@types/prop-types": "^15.7.3",
+    "@types/react": "^16.9.16",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
     "babel-preset-buildo": "^0.1.1",
-    "css-loader": "^0.28.5",
-    "enzyme": "^3.2.0",
-    "enzyme-adapter-react-16": "^1.1.0",
-    "file-loader": "^1.1.5",
-    "jest": "^22",
-    "node-sass": "^4.8.3",
-    "progress-bar-webpack-plugin": "^1.10.0",
-    "raf": "^3.4.0",
+    "css-loader": "^0.28.11",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.15.1",
+    "file-loader": "^1.1.11",
+    "jest": "^24.9.0",
+    "lodash": "^4.17.15",
+    "node-sass": "^4.13.0",
+    "progress-bar-webpack-plugin": "^1.12.1",
+    "raf": "^3.4.1",
     "raw-loader": "^0.5.1",
-    "react": "^16",
-    "react-docgen-typescript": "^1.1.0",
-    "react-dom": "^16",
+    "react": "^16.8.0",
+    "react-docgen-typescript": "^1.16.1",
+    "react-dom": "^16.8.0",
     "react-styleguidist": "^6.0.33",
-    "react-test-renderer": "^16.2.0",
-    "sass-loader": "^6.0.6",
-    "smooth-release": "^8.0.4",
-    "ts-jest": "^22",
-    "ts-loader": "^2.3.3",
-    "typescript": "^2.8.1",
+    "react-test-renderer": "^16.8.0",
+    "sass-loader": "^6.0.7",
+    "smooth-release": "^8.0.9",
+    "ts-jest": "^24.2.0",
+    "ts-loader": "^3.5.0",
+    "typescript": "~3.6.4",
     "webpack": "3.5.5"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15 || ^16",
-    "react-dom": "^0.14 || ^15 || ^16"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "jest": {
     "testURL": "http://localhost",
@@ -77,7 +80,7 @@
       "<rootDir>/tests/setup.js"
     ],
     "transform": {
-      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(.*[.](test))[.](tsx?)$",
     "moduleFileExtensions": [

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -99,9 +99,10 @@ const ReactPlaceholder: React.FC<Props> = ({
       : className;
 
     if (customPlaceholder && React.isValidElement(customPlaceholder)) {
-      const mergedCustomClasses = [customPlaceholder.props.className, classes]
-        .filter(c => c)
-        .join(' ');
+      const mergedCustomClasses = joinClassNames(
+        customPlaceholder.props.className,
+        classes
+      );
       return React.cloneElement(customPlaceholder, {
         className: mergedCustomClasses
       });

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as placeholders from './placeholders';
 import { joinClassNames } from './utils';
 
-export type CommonProps = {
+type CommonProps = {
   children: React.ReactElement | null;
   /** pass `true` when the content is ready and `false` when it's loading */
   ready: boolean;
@@ -14,7 +14,7 @@ export type CommonProps = {
   style?: React.CSSProperties;
 };
 
-export type PlaceholderProps = CommonProps & {
+type PlaceholderProps = CommonProps & {
   // we have a default color, so we can set this as optional
   color?: string;
   // we have a default number of rows, so we can set this as optional
@@ -23,7 +23,7 @@ export type PlaceholderProps = CommonProps & {
   customPlaceholder?: undefined;
 };
 
-export type CustomPlaceholderProps = CommonProps & {
+type CustomPlaceholderProps = CommonProps & {
   /** pass any renderable content to be used as placeholder instead of the built-in ones */
   customPlaceholder?: React.ReactElement<{ [k: string]: any }> | null;
   type?: undefined;

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -89,6 +89,7 @@ export default class ReactPlaceholder extends React.Component<Props> {
 
     const Placeholder = placeholders[type!];
 
+    // @ts-ignore
     return <Placeholder {...rest} className={classes} />;
   };
 

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -17,6 +17,8 @@ export type CommonProps = {
 export type PlaceholderProps = CommonProps & {
   // we have a default color, so we can set this as optional
   color?: string;
+  // we have a default color, so we can set this as optional
+  rows?: number;
   showLoadingAnimation?: boolean;
   customPlaceholder?: undefined;
 };
@@ -33,7 +35,7 @@ export type CustomPlaceholderProps = CommonProps & {
 type MediaPlaceholderProps = PlaceholderProps &
   Omit<
     React.ComponentProps<typeof placeholders.media>,
-    'color' | 'children'
+    'color' | 'rows' | 'children'
   > & {
     type: 'media';
   };
@@ -52,7 +54,10 @@ type RoundPlaceholderProps = PlaceholderProps &
   };
 
 type TextPlaceholderProps = PlaceholderProps &
-  Omit<React.ComponentProps<typeof placeholders.text>, 'color' | 'children'> & {
+  Omit<
+    React.ComponentProps<typeof placeholders.text>,
+    'color' | 'rows' | 'children'
+  > & {
     type: 'text';
   };
 
@@ -76,6 +81,7 @@ const ReactPlaceholder: React.FC<Props> = ({
   delay = 0,
   type = 'text',
   color = '#CDCDCD',
+  rows = 3,
   ready: readyProp,
   firstLaunchOnly,
   children,
@@ -105,14 +111,8 @@ const ReactPlaceholder: React.FC<Props> = ({
 
     const Placeholder = placeholders[type];
 
-    // unsure how to properly get the compiler to conditionally recognize rows
     return (
-      <Placeholder
-        {...rest}
-        color={color}
-        rows={(rest as { rows: number }).rows}
-        className={classes}
-      />
+      <Placeholder {...rest} color={color} rows={rows} className={classes} />
     );
   };
 

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -17,7 +17,7 @@ export type CommonProps = {
 export type PlaceholderProps = CommonProps & {
   // we have a default color, so we can set this as optional
   color?: string;
-  // we have a default color, so we can set this as optional
+  // we have a default number of rows, so we can set this as optional
   rows?: number;
   showLoadingAnimation?: boolean;
   customPlaceholder?: undefined;

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -137,6 +137,16 @@ const ReactPlaceholder: React.FC<Props> = ({
     }
   }, [firstLaunchOnly, ready, readyProp, delay]);
 
+  // clear the timeout when the component unmounts
+  React.useEffect(
+    () => () => {
+      if (timeout.current) {
+        window.clearTimeout(timeout.current);
+      }
+    },
+    []
+  );
+
   return ready ? children : getFiller();
 };
 

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -3,7 +3,7 @@ import * as placeholders from './placeholders';
 import { joinClassNames } from './utils';
 
 export type CommonProps = {
-  children: React.ReactNode;
+  children: React.ReactElement | null;
   /** pass `true` when the content is ready and `false` when it's loading */
   ready: boolean;
   /** delay in millis to wait when passing from ready to NOT ready */
@@ -23,9 +23,7 @@ export type PlaceholderProps = CommonProps & {
 
 export type CustomPlaceholderProps = CommonProps & {
   /** pass any renderable content to be used as placeholder instead of the built-in ones */
-  customPlaceholder?:
-    | React.ReactNode
-    | React.ReactElement<{ [k: string]: any }>;
+  customPlaceholder: React.ReactElement<{ [k: string]: any }> | null;
   type?: undefined;
   rows?: undefined;
   color?: undefined;
@@ -89,7 +87,7 @@ const ReactPlaceholder: React.FC<Props> = ({
   const [ready, setReady] = React.useState(readyProp);
   const timeout = React.useRef<null | number>(null);
 
-  const getFiller = (): React.ReactNode => {
+  const getFiller = (): React.ReactElement | null => {
     const classes = showLoadingAnimation
       ? joinClassNames('show-loading-animation', className)
       : className;

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import * as placeholders from './placeholders';
 
 export type CommonProps = {
@@ -34,26 +33,6 @@ export type Props = (CommonProps & {
 })
 
 export default class ReactPlaceholder extends React.Component<Props> {
-
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.element
-    ]).isRequired,
-    delay: PropTypes.number,
-    ready: PropTypes.bool.isRequired,
-    firstLaunchOnly: PropTypes.bool,
-    type: PropTypes.oneOf(['text', 'media', 'textRow', 'rect', 'round']),
-    rows: PropTypes.number,
-    color: PropTypes.string,
-    showLoadingAnimation: PropTypes.bool,
-    customPlaceholder: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.element
-    ]),
-    className: PropTypes.string,
-    style: PropTypes.object
-  }
 
   static defaultProps = {
     delay: 0,

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -25,7 +25,7 @@ export type PlaceholderProps = CommonProps & {
 
 export type CustomPlaceholderProps = CommonProps & {
   /** pass any renderable content to be used as placeholder instead of the built-in ones */
-  customPlaceholder: React.ReactElement<{ [k: string]: any }> | null;
+  customPlaceholder?: React.ReactElement<{ [k: string]: any }> | null;
   type?: undefined;
   rows?: undefined;
   color?: undefined;

--- a/src/placeholders/MediaBlock.tsx
+++ b/src/placeholders/MediaBlock.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import TextBlock from './TextBlock';
 import RoundShape from './RoundShape';
 
@@ -11,13 +10,6 @@ export type Props = {
 }
 
 export default class MediaBlock extends React.Component<Props> {
-
-  static propTypes = {
-    rows: PropTypes.number.isRequired,
-    color: PropTypes.string.isRequired,
-    style: PropTypes.object,
-    className: PropTypes.string
-  }
 
   render() {
     const { className, style, color, rows } = this.props;

--- a/src/placeholders/MediaBlock.tsx
+++ b/src/placeholders/MediaBlock.tsx
@@ -1,34 +1,32 @@
 import * as React from 'react';
 import TextBlock from './TextBlock';
 import RoundShape from './RoundShape';
+import { joinClassNames } from '../utils';
 
 export type Props = {
-  rows: number,
-  color: string,
-  style?: React.CSSProperties,
-  className?: string
-}
+  rows: number;
+  color: string;
+  style?: React.CSSProperties;
+  className?: string;
+};
 
-export default class MediaBlock extends React.Component<Props> {
+const defaultStyles = {
+  display: 'flex'
+};
 
-  render() {
-    const { className, style, color, rows } = this.props;
+const MediaBlock: React.FC<Props> = ({ className, style, color, rows }) => {
+  return (
+    <div
+      className={joinClassNames('media-block', className)}
+      style={{ ...defaultStyles, ...style }}
+    >
+      <RoundShape
+        color={color}
+        style={{ minHeight: 55, width: 55, minWidth: 55, marginRight: 10 }}
+      />
+      <TextBlock color={color} rows={rows} />
+    </div>
+  );
+};
 
-    const defaultStyles = {
-      display: 'flex'
-    };
-
-    const classes = ['media-block', className].filter(c => c).join(' ');
-
-    return (
-      <div className={classes} style={{ ...defaultStyles, ...style }}>
-        <RoundShape
-          color={color}
-          style={{ minHeight: 55, width: 55, minWidth: 55, marginRight: 10 }}
-        />
-        <TextBlock color={color} rows={rows} />
-      </div>
-    );
-  }
-
-}
+export default MediaBlock;

--- a/src/placeholders/RectShape.tsx
+++ b/src/placeholders/RectShape.tsx
@@ -1,28 +1,26 @@
 import * as React from 'react';
+import { joinClassNames } from '../utils';
 
 export type Props = {
-  color?: string,
-  className?: string,
-  style?: React.CSSProperties
-}
+  color?: string;
+  className?: string;
+  style?: React.CSSProperties;
+};
 
-export default class RectShape extends React.Component<Props> {
+const RectShape: React.FC<Props> = ({ className, style, color }) => {
+  const defaultStyle = {
+    backgroundColor: color,
+    width: '100%',
+    height: '100%',
+    marginRight: 10
+  };
 
-  render() {
-    const { className, style, color } = this.props;
+  return (
+    <div
+      className={joinClassNames('rect-shape', className)}
+      style={{ ...defaultStyle, ...style }}
+    />
+  );
+};
 
-    const defaultStyle = {
-      backgroundColor: color,
-      width: '100%',
-      height: '100%',
-      marginRight: 10
-    };
-
-    const classes = ['rect-shape', className].filter(c => c).join(' ');
-
-    return (
-      <div className={classes} style={{ ...defaultStyle, ...style }} />
-    );
-  }
-
-}
+export default RectShape;

--- a/src/placeholders/RectShape.tsx
+++ b/src/placeholders/RectShape.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export type Props = {
   color?: string,
@@ -8,12 +7,6 @@ export type Props = {
 }
 
 export default class RectShape extends React.Component<Props> {
-
-  static propTypes = {
-    color: PropTypes.string,
-    className: PropTypes.string,
-    style: PropTypes.object
-  }
 
   render() {
     const { className, style, color } = this.props;

--- a/src/placeholders/RoundShape.tsx
+++ b/src/placeholders/RoundShape.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export type Props = {
   color: string,
@@ -8,12 +7,6 @@ export type Props = {
 }
 
 export default class RoundShape extends React.Component<Props> {
-
-  static propTypes = {
-    color: PropTypes.string.isRequired,
-    className: PropTypes.string,
-    style: PropTypes.object
-  }
 
   render() {
     const { className, style, color } = this.props;

--- a/src/placeholders/RoundShape.tsx
+++ b/src/placeholders/RoundShape.tsx
@@ -1,28 +1,26 @@
 import * as React from 'react';
+import { joinClassNames } from '../utils';
 
 export type Props = {
-  color: string,
-  style?: React.CSSProperties,
-  className?: string
-}
+  color: string;
+  style?: React.CSSProperties;
+  className?: string;
+};
 
-export default class RoundShape extends React.Component<Props> {
+const RoundShape: React.FC<Props> = ({ className, style, color }) => {
+  const defaultStyles = {
+    backgroundColor: color,
+    borderRadius: '500rem',
+    width: '100%',
+    height: '100%'
+  };
 
-  render() {
-    const { className, style, color } = this.props;
+  return (
+    <div
+      className={joinClassNames('round-shape', className)}
+      style={{ ...defaultStyles, ...style }}
+    />
+  );
+};
 
-    const defaultStyles = {
-      backgroundColor: color,
-      borderRadius: '500rem',
-      width: '100%',
-      height: '100%'
-    };
-
-    const classes = ['round-shape', className].filter(c => c).join(' ');
-
-    return (
-      <div className={classes} style={{ ...defaultStyles, ...style }} />
-    );
-  }
-
-}
+export default RoundShape;

--- a/src/placeholders/TextBlock.tsx
+++ b/src/placeholders/TextBlock.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import TextRow from './TextRow';
 
 export type DefaultedProps = Props & {
@@ -16,18 +15,6 @@ export type Props = {
 }
 
 export default class TextBlock extends React.Component<Props> {
-
-  static propTypes = {
-    rows: PropTypes.number.isRequired,
-    color: PropTypes.string.isRequired,
-    lineSpacing: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    widths: PropTypes.arrayOf(PropTypes.number),
-    style: PropTypes.object,
-    className: PropTypes.string
-  }
 
   static defaultProps: Partial<Props> = {
     widths: [97, 100, 94, 90, 98, 95, 98, 40]

--- a/src/placeholders/TextBlock.tsx
+++ b/src/placeholders/TextBlock.tsx
@@ -1,62 +1,52 @@
 import * as React from 'react';
 import TextRow from './TextRow';
-
-export type DefaultedProps = Props & {
-  widths: NonNullable<Props['widths']>
-}
+import { joinClassNames } from '../utils';
 
 export type Props = {
-  rows: number,
-  color: string,
-  lineSpacing?: string | number,
-  widths?: number[],
-  style?: React.CSSProperties,
-  className?: string
-}
+  rows: number;
+  color: string;
+  lineSpacing?: string | number;
+  widths?: number[];
+  style?: React.CSSProperties;
+  className?: string;
+};
 
-export default class TextBlock extends React.Component<Props> {
+const defaultStyles = {
+  width: '100%'
+};
 
-  static defaultProps: Partial<Props> = {
-    widths: [97, 100, 94, 90, 98, 95, 98, 40]
-  }
+const defaultWidths = [97, 100, 94, 90, 98, 95, 98, 40];
 
-  getRowStyle = (i: number) => {
-    const { rows, widths } = this.props as DefaultedProps;
-
+const TextBlock: React.FC<Props> = ({
+  rows,
+  lineSpacing,
+  color,
+  style,
+  className,
+  widths = defaultWidths
+}) => {
+  const getRowStyle = (i: number) => {
     return {
-      maxHeight: `${(100 / (rows * 2 - 1))}%`,
+      maxHeight: `${100 / (rows * 2 - 1)}%`,
       width: `${widths[(i + widths.length) % widths.length]}%`
     };
-  }
+  };
 
-  getRows = () => {
-    const { rows, lineSpacing, color } = this.props;
-    const range = Array.apply(null, Array(rows));
-    return range.map((_, i) => (
-      <TextRow
-        color={color}
-        style={this.getRowStyle(i)}
-        lineSpacing={i !== 0 ? lineSpacing : 0}
-        key={i}
-      />
-    ));
-  }
+  return (
+    <div
+      className={joinClassNames('text-block', className)}
+      style={{ ...defaultStyles, ...style }}
+    >
+      {Array.apply(null, Array(rows)).map((_, i) => (
+        <TextRow
+          color={color}
+          style={getRowStyle(i)}
+          lineSpacing={i !== 0 ? lineSpacing : 0}
+          key={i}
+        />
+      ))}
+    </div>
+  );
+};
 
-  render() {
-    const { style, className } = this.props;
-
-
-    const defaultStyles = {
-      width: '100%'
-    };
-
-    const classes = ['text-block', className].filter(c => c).join(' ');
-
-    return (
-      <div className={classes} style={{ ...defaultStyles, ...style }}>
-        {this.getRows()}
-      </div>
-    );
-  }
-
-}
+export default TextBlock;

--- a/src/placeholders/TextBlock.tsx
+++ b/src/placeholders/TextBlock.tsx
@@ -44,7 +44,7 @@ export default class TextBlock extends React.Component<Props> {
 
   getRows = () => {
     const { rows, lineSpacing, color } = this.props;
-    const range: undefined[] = Array.apply(null, Array(rows));
+    const range = Array.apply(null, Array(rows));
     return range.map((_, i) => (
       <TextRow
         color={color}

--- a/src/placeholders/TextRow.tsx
+++ b/src/placeholders/TextRow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 export type Props = {
   maxHeight?: string | number,
-  invisible?: boolean,
   className?: string,
   color: string,
   style?: React.CSSProperties,

--- a/src/placeholders/TextRow.tsx
+++ b/src/placeholders/TextRow.tsx
@@ -1,38 +1,35 @@
 import * as React from 'react';
+import { joinClassNames } from '../utils';
 
 export type Props = {
-  maxHeight?: string | number,
-  className?: string,
-  color: string,
-  style?: React.CSSProperties,
-  lineSpacing?: string | number
-}
+  maxHeight?: string | number;
+  className?: string;
+  color: string;
+  style?: React.CSSProperties;
+  lineSpacing?: string | number;
+};
 
-export default class TextRow extends React.Component<Props> {
+const TextRow: React.FC<Props> = ({
+  className,
+  maxHeight,
+  color,
+  lineSpacing,
+  style
+}) => {
+  const defaultStyles = {
+    maxHeight,
+    width: '100%',
+    height: '1em',
+    backgroundColor: color,
+    marginTop: lineSpacing || '0.7em'
+  };
 
-  static defaultProps = {
-    lineSpacing: '0.7em'
-  }
+  return (
+    <div
+      className={joinClassNames('text-row', className)}
+      style={{ ...defaultStyles, ...style }}
+    />
+  );
+};
 
-  render() {
-    const { className, maxHeight, color, lineSpacing, style } = this.props;
-
-    const defaultStyles = {
-      maxHeight,
-      width: '100%',
-      height: '1em',
-      backgroundColor: color,
-      marginTop: lineSpacing
-    };
-
-    const classes = ['text-row', className].filter(c => c).join(' ');
-
-    return (
-      <div
-        className={classes}
-        style={{ ...defaultStyles, ...style }}
-      />
-    );
-  }
-
-}
+export default TextRow;

--- a/src/placeholders/TextRow.tsx
+++ b/src/placeholders/TextRow.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export type Props = {
   maxHeight?: string | number,
@@ -11,20 +10,6 @@ export type Props = {
 }
 
 export default class TextRow extends React.Component<Props> {
-
-  static propTypes = {
-    maxHeight: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    className: PropTypes.string,
-    color: PropTypes.string.isRequired,
-    lineSpacing: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    style: PropTypes.object
-  }
 
   static defaultProps = {
     lineSpacing: '0.7em'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,2 @@
+export const joinClassNames = (...classNames: (string | undefined)[]) =>
+  classNames.filter(c => c).join(' ');

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -22,6 +22,18 @@ describe('ReactPlaceholder', () => {
     expect(tree.getElements()).toMatchSnapshot();
   });
 
+  it('renders the text placeholder with the lineSpacing set', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="text" rows={2} ready={false} lineSpacing={3}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.find('TextBlock').prop('lineSpacing')).toBe(3);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
   it('renders the media placeholder when the content is not ready', () => {
     const content = <div>Some content still loading...</div>;
     const tree = shallow(

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -9,11 +9,66 @@ import { shallow } from 'enzyme';
 jest.useFakeTimers();
 
 describe('ReactPlaceholder', () => {
-
-  it('renders the placeholder when the content is not ready', () => {
+  it('renders the text placeholder when the content is not ready', () => {
     const content = <div>Some content still loading...</div>;
     const tree = shallow(
-      <ReactPlaceholder type='text' rows={2} ready={false}>
+      <ReactPlaceholder type="text" rows={2} ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders the media placeholder when the content is not ready', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="media" rows={2} ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders the textRow placeholder when the content is not ready', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="textRow" ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders the rect placeholder when the content is not ready', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="rect" ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders the round placeholder when the content is not ready', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="round" ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders a custom placeholder when the content is not ready', () => {
+    const content = <div>Some ready content</div>;
+    const customPlaceholder = <div>Custom Placeholder</div>;
+    const tree = shallow(
+      <ReactPlaceholder ready={false} customPlaceholder={customPlaceholder}>
         {content}
       </ReactPlaceholder>
     );
@@ -24,12 +79,7 @@ describe('ReactPlaceholder', () => {
   it('renders the placeholder only after the specified delay', () => {
     const content = <div>Some content still loading...</div>;
     const tree = shallow(
-      <ReactPlaceholder
-        ready
-        type='text'
-        rows={2}
-        delay={10000}
-      >
+      <ReactPlaceholder ready type="text" rows={2} delay={10000}>
         {content}
       </ReactPlaceholder>
     );
@@ -43,37 +93,38 @@ describe('ReactPlaceholder', () => {
     expect(tree.getElements()).toMatchSnapshot();
   });
 
-  it('renders the content when it\'s ready', () => {
+  it("renders the content when it's ready", () => {
     const content = <div>Some ready content</div>;
     const tree = shallow(
-      <ReactPlaceholder type='text' rows={2} ready>
+      <ReactPlaceholder type="text" rows={2} ready>
         {content}
       </ReactPlaceholder>
     );
     expect(tree.contains(content)).toBe(true);
     expect(tree.getElements()).toMatchSnapshot();
   });
-
 });
 
 describe('build', () => {
-
   it('build script generates every needed file', () => {
-    execSync('npm run build', { stdio:[] })
+    execSync('npm run build', { stdio: [] });
 
     const libPath = path.resolve(__dirname, '../lib');
 
     const libFiles = fs.readdirSync(libPath);
 
-    const files = flatten(libFiles.map(fileInRoot => {
-      const filePath = path.resolve(libPath, fileInRoot);
-      if (fs.lstatSync(filePath).isDirectory()) {
-        return fs.readdirSync(filePath).map(fileInFolder => `${fileInRoot}/${fileInFolder}`);
-      }
-      return fileInRoot;
-    }));
+    const files = flatten(
+      libFiles.map(fileInRoot => {
+        const filePath = path.resolve(libPath, fileInRoot);
+        if (fs.lstatSync(filePath).isDirectory()) {
+          return fs
+            .readdirSync(filePath)
+            .map(fileInFolder => `${fileInRoot}/${fileInFolder}`);
+        }
+        return fileInRoot;
+      })
+    );
 
     expect(files).toMatchSnapshot();
-  })
-
-})
+  });
+});

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import flatten = require('lodash/flatten');
+import { flatten } from 'lodash';
 import ReactPlaceholder from '../src/ReactPlaceholder';
 import { shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
 
 jest.useFakeTimers();
 

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -146,6 +146,32 @@ describe('ReactPlaceholder', () => {
     expect(queryByText('Some ready content')).toBeInTheDocument();
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('renders content when firstLaunchOnly is true and ready changes to true, and keeps it rendered when ready changes to false', () => {
+    const content = <div>Some ready content</div>;
+    const { queryByText, container, rerender } = render(
+      <ReactPlaceholder type="rect" ready={false} firstLaunchOnly={true}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(queryByText('Some ready content')).not.toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+
+    rerender(<ReactPlaceholder  type="rect" ready={true} firstLaunchOnly={true}>
+      {content}
+    </ReactPlaceholder>);
+
+    expect(queryByText('Some ready content')).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+
+    rerender(<ReactPlaceholder  type="rect" ready={false} firstLaunchOnly={true}>
+      {content}
+    </ReactPlaceholder>);
+
+    // content is still rendered
+    expect(queryByText('Some ready content')).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });
 
 describe('build', () => {

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -90,19 +90,6 @@ describe('ReactPlaceholder', () => {
     expect(tree.getElements()).toMatchSnapshot();
   });
 
-  it('renders a string custom placeholder when the content is not ready', () => {
-    const content = <div>Some ready content</div>;
-    const customPlaceholder = 'Custom Placeholder';
-    const tree = shallow(
-      <ReactPlaceholder ready={false} customPlaceholder={customPlaceholder}>
-        {content}
-      </ReactPlaceholder>
-    );
-    expect(tree.contains(content)).toBe(false);
-    expect(tree.text()).toBe(customPlaceholder);
-    expect(tree.getElements()).toMatchSnapshot();
-  });
-
   it('renders the placeholder only after the specified delay', () => {
     const content = <div>Some content still loading...</div>;
     const tree = shallow(

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -64,6 +64,17 @@ describe('ReactPlaceholder', () => {
     expect(tree.getElements()).toMatchSnapshot();
   });
 
+  it('renders the round placeholder with animation when the content is not ready', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="round" ready={false} showLoadingAnimation>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
   it('renders a custom placeholder when the content is not ready', () => {
     const content = <div>Some ready content</div>;
     const customPlaceholder = <div>Custom Placeholder</div>;
@@ -73,6 +84,22 @@ describe('ReactPlaceholder', () => {
       </ReactPlaceholder>
     );
     expect(tree.contains(content)).toBe(false);
+    // an empty className is injected to the customer placeholder element,
+    // so we'll check the children for now
+    expect(tree.text()).toBe(customPlaceholder.props.children);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it('renders a string custom placeholder when the content is not ready', () => {
+    const content = <div>Some ready content</div>;
+    const customPlaceholder = 'Custom Placeholder';
+    const tree = shallow(
+      <ReactPlaceholder ready={false} customPlaceholder={customPlaceholder}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.text()).toBe(customPlaceholder);
     expect(tree.getElements()).toMatchSnapshot();
   });
 
@@ -100,6 +127,27 @@ describe('ReactPlaceholder', () => {
         {content}
       </ReactPlaceholder>
     );
+    expect(tree.contains(content)).toBe(true);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
+  it("renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready", () => {
+    const content = <div>Some ready content</div>;
+    const tree = shallow(
+      <ReactPlaceholder type="text" rows={2} ready>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(true);
+    expect(tree.getElements()).toMatchSnapshot();
+
+    tree.setProps({ ready: false });
+
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+
+    tree.setProps({ ready: true });
+
     expect(tree.contains(content)).toBe(true);
     expect(tree.getElements()).toMatchSnapshot();
   });

--- a/tests/ReactPlaceholder.test.tsx
+++ b/tests/ReactPlaceholder.test.tsx
@@ -11,6 +11,17 @@ import '@testing-library/jest-dom/extend-expect';
 jest.useFakeTimers();
 
 describe('ReactPlaceholder', () => {
+  it('renders the text placeholder with 3 rows as the default placeholder', () => {
+    const content = <div>Some content still loading...</div>;
+    const tree = shallow(
+      <ReactPlaceholder ready={false}>
+        {content}
+      </ReactPlaceholder>
+    );
+    expect(tree.contains(content)).toBe(false);
+    expect(tree.getElements()).toMatchSnapshot();
+  });
+
   it('renders the text placeholder when the content is not ready', () => {
     const content = <div>Some content still loading...</div>;
     const tree = shallow(

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -10,12 +10,6 @@ Array [
 ]
 `;
 
-exports[`ReactPlaceholder renders a string custom placeholder when the content is not ready 1`] = `
-Array [
-  null,
-]
-`;
-
 exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 1`] = `
 Array [
   <div>
@@ -54,7 +48,6 @@ exports[`ReactPlaceholder renders the media placeholder when the content is not 
 Array [
   <MediaBlock
     color="#CDCDCD"
-    delay={0}
     rows={2}
   />,
 ]
@@ -74,7 +67,7 @@ exports[`ReactPlaceholder renders the rect placeholder when the content is not r
 Array [
   <RectShape
     color="#CDCDCD"
-    delay={0}
+    rows={3}
   />,
 ]
 `;
@@ -83,7 +76,7 @@ exports[`ReactPlaceholder renders the round placeholder when the content is not 
 Array [
   <RoundShape
     color="#CDCDCD"
-    delay={0}
+    rows={3}
   />,
 ]
 `;
@@ -93,7 +86,7 @@ Array [
   <RoundShape
     className="show-loading-animation"
     color="#CDCDCD"
-    delay={0}
+    rows={3}
   />,
 ]
 `;
@@ -102,7 +95,6 @@ exports[`ReactPlaceholder renders the text placeholder when the content is not r
 Array [
   <TextBlock
     color="#CDCDCD"
-    delay={0}
     rows={2}
   />,
 ]
@@ -112,7 +104,7 @@ exports[`ReactPlaceholder renders the textRow placeholder when the content is no
 Array [
   <TextRow
     color="#CDCDCD"
-    delay={0}
+    rows={3}
   />,
 ]
 `;

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -10,6 +10,50 @@ Array [
 ]
 `;
 
+exports[`ReactPlaceholder renders a string custom placeholder when the content is not ready 1`] = `
+Array [
+  null,
+]
+`;
+
+exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 1`] = `
+Array [
+  <div>
+    Some ready content
+  </div>,
+]
+`;
+
+exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 2`] = `
+Array [
+  <TextBlock
+    color="#CDCDCD"
+    delay={0}
+    rows={2}
+    widths={
+      Array [
+        97,
+        100,
+        94,
+        90,
+        98,
+        95,
+        98,
+        40,
+      ]
+    }
+  />,
+]
+`;
+
+exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 3`] = `
+Array [
+  <div>
+    Some ready content
+  </div>,
+]
+`;
+
 exports[`ReactPlaceholder renders the content when it's ready 1`] = `
 Array [
   <div>
@@ -62,6 +106,16 @@ Array [
 exports[`ReactPlaceholder renders the round placeholder when the content is not ready 1`] = `
 Array [
   <RoundShape
+    color="#CDCDCD"
+    delay={0}
+  />,
+]
+`;
+
+exports[`ReactPlaceholder renders the round placeholder with animation when the content is not ready 1`] = `
+Array [
+  <RoundShape
+    className="show-loading-animation"
     color="#CDCDCD"
     delay={0}
   />,

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -10,6 +10,25 @@ Array [
 ]
 `;
 
+exports[`ReactPlaceholder renders content when firstLaunchOnly is true and ready changes to true, and keeps it rendered when ready changes to false 1`] = `
+<div
+  class="rect-shape"
+  style="background-color: rgb(205, 205, 205); width: 100%; height: 100%; margin-right: 10px;"
+/>
+`;
+
+exports[`ReactPlaceholder renders content when firstLaunchOnly is true and ready changes to true, and keeps it rendered when ready changes to false 2`] = `
+<div>
+  Some ready content
+</div>
+`;
+
+exports[`ReactPlaceholder renders content when firstLaunchOnly is true and ready changes to true, and keeps it rendered when ready changes to false 3`] = `
+<div>
+  Some ready content
+</div>
+`;
+
 exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 1`] = `
 <div>
   Some ready content

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -11,7 +11,6 @@ Array [
 exports[`ReactPlaceholder renders the placeholder only after the specified delay 1`] = `
 Array [
   <TextBlock
-    className={undefined}
     color="#CDCDCD"
     delay={10000}
     rows={2}
@@ -34,7 +33,6 @@ Array [
 exports[`ReactPlaceholder renders the placeholder when the content is not ready 1`] = `
 Array [
   <TextBlock
-    className={undefined}
     color="#CDCDCD"
     delay={0}
     rows={2}

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -1,10 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ReactPlaceholder renders a custom placeholder when the content is not ready 1`] = `
+Array [
+  <div
+    className=""
+  >
+    Custom Placeholder
+  </div>,
+]
+`;
+
 exports[`ReactPlaceholder renders the content when it's ready 1`] = `
 Array [
   <div>
     Some ready content
   </div>,
+]
+`;
+
+exports[`ReactPlaceholder renders the media placeholder when the content is not ready 1`] = `
+Array [
+  <MediaBlock
+    color="#CDCDCD"
+    delay={0}
+    rows={2}
+  />,
 ]
 `;
 
@@ -30,7 +50,25 @@ Array [
 ]
 `;
 
-exports[`ReactPlaceholder renders the placeholder when the content is not ready 1`] = `
+exports[`ReactPlaceholder renders the rect placeholder when the content is not ready 1`] = `
+Array [
+  <RectShape
+    color="#CDCDCD"
+    delay={0}
+  />,
+]
+`;
+
+exports[`ReactPlaceholder renders the round placeholder when the content is not ready 1`] = `
+Array [
+  <RoundShape
+    color="#CDCDCD"
+    delay={0}
+  />,
+]
+`;
+
+exports[`ReactPlaceholder renders the text placeholder when the content is not ready 1`] = `
 Array [
   <TextBlock
     color="#CDCDCD"
@@ -48,6 +86,16 @@ Array [
         40,
       ]
     }
+  />,
+]
+`;
+
+exports[`ReactPlaceholder renders the textRow placeholder when the content is not ready 1`] = `
+Array [
+  <TextRow
+    color="#CDCDCD"
+    delay={0}
+    lineSpacing="0.7em"
   />,
 ]
 `;

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -127,6 +127,16 @@ Array [
 ]
 `;
 
+exports[`ReactPlaceholder renders the text placeholder with the lineSpacing set 1`] = `
+Array [
+  <TextBlock
+    color="#CDCDCD"
+    lineSpacing={3}
+    rows={2}
+  />,
+]
+`;
+
 exports[`ReactPlaceholder renders the textRow placeholder when the content is not ready 1`] = `
 Array [
   <TextRow

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -11,29 +11,31 @@ Array [
 `;
 
 exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 1`] = `
-Array [
-  <div>
-    Some ready content
-  </div>,
-]
+<div>
+  Some ready content
+</div>
 `;
 
 exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 2`] = `
-Array [
-  <TextBlock
-    color="#CDCDCD"
-    delay={0}
-    rows={2}
-  />,
-]
+<div
+  class="text-block"
+  style="width: 100%;"
+>
+  <div
+    class="text-row"
+    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+  />
+  <div
+    class="text-row"
+    style="max-height: 33.333333333333336%; width: 100%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+  />
+</div>
 `;
 
 exports[`ReactPlaceholder renders content when it's ready, then a placeholder when it's not ready, and finally content again when it's ready 3`] = `
-Array [
-  <div>
-    Some ready content
-  </div>,
-]
+<div>
+  Some ready content
+</div>
 `;
 
 exports[`ReactPlaceholder renders the content when it's ready 1`] = `
@@ -54,13 +56,19 @@ Array [
 `;
 
 exports[`ReactPlaceholder renders the placeholder only after the specified delay 1`] = `
-Array [
-  <TextBlock
-    color="#CDCDCD"
-    delay={10000}
-    rows={2}
-  />,
-]
+<div
+  class="text-block"
+  style="width: 100%;"
+>
+  <div
+    class="text-row"
+    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+  />
+  <div
+    class="text-row"
+    style="max-height: 33.333333333333336%; width: 100%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+  />
+</div>
 `;
 
 exports[`ReactPlaceholder renders the rect placeholder when the content is not ready 1`] = `

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -127,6 +127,15 @@ Array [
 ]
 `;
 
+exports[`ReactPlaceholder renders the text placeholder with 3 rows as the default placeholder 1`] = `
+Array [
+  <TextBlock
+    color="#CDCDCD"
+    rows={3}
+  />,
+]
+`;
+
 exports[`ReactPlaceholder renders the text placeholder with the lineSpacing set 1`] = `
 Array [
   <TextBlock

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -30,18 +30,6 @@ Array [
     color="#CDCDCD"
     delay={0}
     rows={2}
-    widths={
-      Array [
-        97,
-        100,
-        94,
-        90,
-        98,
-        95,
-        98,
-        40,
-      ]
-    }
   />,
 ]
 `;
@@ -78,18 +66,6 @@ Array [
     color="#CDCDCD"
     delay={10000}
     rows={2}
-    widths={
-      Array [
-        97,
-        100,
-        94,
-        90,
-        98,
-        95,
-        98,
-        40,
-      ]
-    }
   />,
 ]
 `;
@@ -128,18 +104,6 @@ Array [
     color="#CDCDCD"
     delay={0}
     rows={2}
-    widths={
-      Array [
-        97,
-        100,
-        94,
-        90,
-        98,
-        95,
-        98,
-        40,
-      ]
-    }
   />,
 ]
 `;
@@ -149,7 +113,6 @@ Array [
   <TextRow
     color="#CDCDCD"
     delay={0}
-    lineSpacing="0.7em"
   />,
 ]
 `;
@@ -173,5 +136,7 @@ Array [
   "placeholders/index.d.ts",
   "placeholders/index.js",
   "reactPlaceholder.css",
+  "utils.d.ts",
+  "utils.js",
 ]
 `;

--- a/tests/__snapshots__/placeholders.test.tsx.snap
+++ b/tests/__snapshots__/placeholders.test.tsx.snap
@@ -1,0 +1,302 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`placeholder MediaBlock renders a MediaBlock 1`] = `
+Array [
+  <div
+    className="media-block"
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  >
+    <RoundShape
+      color="rebeccapurple"
+      style={
+        Object {
+          "marginRight": 10,
+          "minHeight": 55,
+          "minWidth": 55,
+          "width": 55,
+        }
+      }
+    />
+    <TextBlock
+      color="rebeccapurple"
+      rows={2}
+      widths={
+        Array [
+          97,
+          100,
+          94,
+          90,
+          98,
+          95,
+          98,
+          40,
+        ]
+      }
+    />
+  </div>,
+]
+`;
+
+exports[`placeholder MediaBlock renders a MediaBlock with custom styles and classNames 1`] = `
+Array [
+  <div
+    className="media-block test more-classes"
+    style={
+      Object {
+        "backgroundColor": "hotpink",
+        "display": "block",
+      }
+    }
+  >
+    <RoundShape
+      color="rebeccapurple"
+      style={
+        Object {
+          "marginRight": 10,
+          "minHeight": 55,
+          "minWidth": 55,
+          "width": 55,
+        }
+      }
+    />
+    <TextBlock
+      color="rebeccapurple"
+      rows={2}
+      widths={
+        Array [
+          97,
+          100,
+          94,
+          90,
+          98,
+          95,
+          98,
+          40,
+        ]
+      }
+    />
+  </div>,
+]
+`;
+
+exports[`placeholder RectShape renders a RectShape 1`] = `
+Array [
+  <div
+    className="rect-shape"
+    style={
+      Object {
+        "backgroundColor": undefined,
+        "height": "100%",
+        "marginRight": 10,
+        "width": "100%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder RectShape renders a RectShape with custom styles, classNames, and color 1`] = `
+Array [
+  <div
+    className="rect-shape test more-classes"
+    style={
+      Object {
+        "backgroundColor": "hotpink",
+        "height": "50%",
+        "marginRight": 5,
+        "width": "50%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder RoundShape renders a RoundShape 1`] = `
+Array [
+  <div
+    className="round-shape"
+    style={
+      Object {
+        "backgroundColor": "rebeccapurple",
+        "borderRadius": "500rem",
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder RoundShape renders a RoundShape with custom styles and classNames 1`] = `
+Array [
+  <div
+    className="round-shape test more-classes"
+    style={
+      Object {
+        "backgroundColor": "hotpink",
+        "borderRadius": "2px",
+        "height": "50%",
+        "width": "50%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder TextBlock renders a TextBlock 1`] = `
+Array [
+  <div
+    className="text-block"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing={0}
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "97%",
+        }
+      }
+    />
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing="0.7em"
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "100%",
+        }
+      }
+    />
+  </div>,
+]
+`;
+
+exports[`placeholder TextBlock renders a TextBlock with custom lineSpacing and widths 1`] = `
+Array [
+  <div
+    className="text-block"
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing={0}
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "10%",
+        }
+      }
+    />
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing={1.5}
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "12%",
+        }
+      }
+    />
+  </div>,
+]
+`;
+
+exports[`placeholder TextBlock renders a TextBlock with custom styles and classNames 1`] = `
+Array [
+  <div
+    className="text-block test more-classes"
+    style={
+      Object {
+        "backgroundColor": "hotpink",
+        "width": "50%",
+      }
+    }
+  >
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing={0}
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "97%",
+        }
+      }
+    />
+    <TextRow
+      color="rebeccapurple"
+      lineSpacing="0.7em"
+      style={
+        Object {
+          "maxHeight": "33.333333333333336%",
+          "width": "100%",
+        }
+      }
+    />
+  </div>,
+]
+`;
+
+exports[`placeholder TextRow renders a TextRow 1`] = `
+Array [
+  <div
+    className="text-row"
+    style={
+      Object {
+        "backgroundColor": "rebeccapurple",
+        "height": "1em",
+        "marginTop": "0.7em",
+        "maxHeight": undefined,
+        "width": "100%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder TextRow renders a TextRow with custom maxHeight and lineSpacing 1`] = `
+Array [
+  <div
+    className="text-row"
+    style={
+      Object {
+        "backgroundColor": "rebeccapurple",
+        "height": "1em",
+        "marginTop": "5rem",
+        "maxHeight": 123,
+        "width": "100%",
+      }
+    }
+  />,
+]
+`;
+
+exports[`placeholder TextRow renders a TextRow with custom styles and classNames, overriding set maxHeight and lineSpacing 1`] = `
+Array [
+  <div
+    className="text-row test more-classes"
+    style={
+      Object {
+        "backgroundColor": "hotpink",
+        "height": "5em",
+        "marginTop": 2,
+        "maxHeight": 50,
+        "width": "50%",
+      }
+    }
+  />,
+]
+`;

--- a/tests/__snapshots__/placeholders.test.tsx.snap
+++ b/tests/__snapshots__/placeholders.test.tsx.snap
@@ -24,18 +24,6 @@ Array [
     <TextBlock
       color="rebeccapurple"
       rows={2}
-      widths={
-        Array [
-          97,
-          100,
-          94,
-          90,
-          98,
-          95,
-          98,
-          40,
-        ]
-      }
     />
   </div>,
 ]
@@ -66,18 +54,6 @@ Array [
     <TextBlock
       color="rebeccapurple"
       rows={2}
-      widths={
-        Array [
-          97,
-          100,
-          94,
-          90,
-          98,
-          95,
-          98,
-          40,
-        ]
-      }
     />
   </div>,
 ]
@@ -169,7 +145,6 @@ Array [
     />
     <TextRow
       color="rebeccapurple"
-      lineSpacing="0.7em"
       style={
         Object {
           "maxHeight": "33.333333333333336%",
@@ -238,7 +213,6 @@ Array [
     />
     <TextRow
       color="rebeccapurple"
-      lineSpacing="0.7em"
       style={
         Object {
           "maxHeight": "33.333333333333336%",

--- a/tests/placeholders.test.tsx
+++ b/tests/placeholders.test.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import {
+  MediaBlock,
+  RectShape,
+  RoundShape,
+  TextBlock,
+  TextRow
+} from '../src/placeholders';
+
+describe('placeholder', () => {
+  describe('MediaBlock', () => {
+    it('renders a MediaBlock', () => {
+      const tree = shallow(<MediaBlock rows={2} color="rebeccapurple" />);
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a MediaBlock with custom styles and classNames', () => {
+      const tree = shallow(
+        <MediaBlock
+          rows={2}
+          color="rebeccapurple"
+          className="test more-classes"
+          style={{
+            backgroundColor: 'hotpink',
+            display: 'block'
+          }}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+  });
+
+  describe('RectShape', () => {
+    it('renders a RectShape', () => {
+      const tree = shallow(<RectShape />);
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a RectShape with custom styles, classNames, and color', () => {
+      const tree = shallow(
+        <RectShape
+          color="rebeccapurple"
+          className="test more-classes"
+          style={{
+            backgroundColor: 'hotpink',
+
+            height: '50%',
+            width: '50%',
+            marginRight: 5
+          }}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+  });
+
+  describe('RoundShape', () => {
+    it('renders a RoundShape', () => {
+      const tree = shallow(<RoundShape color="rebeccapurple" />);
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a RoundShape with custom styles and classNames', () => {
+      const tree = shallow(
+        <RoundShape
+          color="rebeccapurple"
+          className="test more-classes"
+          style={{
+            backgroundColor: 'hotpink',
+            height: '50%',
+            width: '50%',
+            borderRadius: '2px'
+          }}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+  });
+
+  describe('TextBlock', () => {
+    it('renders a TextBlock', () => {
+      const tree = shallow(<TextBlock rows={2} color="rebeccapurple" />);
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a TextBlock with custom lineSpacing and widths', () => {
+      const tree = shallow(
+        <TextBlock
+          rows={2}
+          color="rebeccapurple"
+          lineSpacing={1.5}
+          widths={[10, 12, 15, 13, 14, 11]}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a TextBlock with custom styles and classNames', () => {
+      const tree = shallow(
+        <TextBlock
+          rows={2}
+          color="rebeccapurple"
+          className="test more-classes"
+          style={{
+            backgroundColor: 'hotpink',
+            width: '50%'
+          }}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+  });
+
+  describe('TextRow', () => {
+    it('renders a TextRow', () => {
+      const tree = shallow(<TextRow color="rebeccapurple" />);
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a TextRow with custom maxHeight and lineSpacing', () => {
+      const tree = shallow(
+        <TextRow color="rebeccapurple" maxHeight={123} lineSpacing={'5rem'} />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
+    it('renders a TextRow with custom styles and classNames, overriding set maxHeight and lineSpacing', () => {
+      const tree = shallow(
+        <TextRow
+          color="rebeccapurple"
+          className="test more-classes"
+          maxHeight={123}
+          lineSpacing={'5rem'}
+          style={{
+            backgroundColor: 'hotpink',
+            height: '5em',
+            width: '50%',
+            marginTop: 2,
+            maxHeight: 50
+          }}
+        />
+      );
+
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,11 @@
     "experimentalDecorators": true,
     "outDir": "./lib",
     "baseUrl": ".",
-    "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true,
     "sourceMap": false,
-    "alwaysStrict": true,
+    "strict": true,
     "jsx": "react",
     "lib": [
       "dom", "es6"


### PR DESCRIPTION
Closes [#2520704](https://buildo.kaiten.io/space/32111/card/2520704)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

From the discussion in #83, I refactored the codebase to be built with functional components and hooks. Here's a change log in no particular order:

- Refactor components to all be functional components
- Update the peerDependency of react to be `^16.8.0`
- Change the `children` and `customPlaceholder` types to be `ReactElement` instead of `ReactNode` (this is because the `render` function in a class Component returns a `ReactNode`, where functional components return a `ReactElement`)
- Remove PropTypes
- On the `ReactPlaceholder` component, use a default of `3 for the `rows` props.
- Created more polymorphic TypeScript types for the `ReactPlaceholder` props
- Additional tests
- Upgraded some dependencies
- Upgrade TypeScript to version 3
- Enable strict mode with TypeScript