### PR TITLE
Use default value syntax to set linesSpacing (fixes #86)

### DIFF
--- a/src/placeholders/TextRow.tsx
+++ b/src/placeholders/TextRow.tsx
@@ -13,7 +13,7 @@ const TextRow: React.FC<Props> = ({
   className,
   maxHeight,
   color,
-  lineSpacing,
+  lineSpacing= '0.7em',
   style
 }) => {
   const defaultStyles = {
@@ -21,7 +21,7 @@ const TextRow: React.FC<Props> = ({
     width: '100%',
     height: '1em',
     backgroundColor: color,
-    marginTop: lineSpacing || '0.7em'
+    marginTop: lineSpacing
   };
 
   return (

--- a/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
+++ b/tests/__snapshots__/ReactPlaceholder.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`ReactPlaceholder renders content when it's ready, then a placeholder wh
 >
   <div
     class="text-row"
-    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0px;"
   />
   <div
     class="text-row"
@@ -81,7 +81,7 @@ exports[`ReactPlaceholder renders the placeholder only after the specified delay
 >
   <div
     class="text-row"
-    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0.7em;"
+    style="max-height: 33.333333333333336%; width: 97%; height: 1em; background-color: rgb(205, 205, 205); margin-top: 0px;"
   />
   <div
     class="text-row"

--- a/tests/__snapshots__/placeholders.test.tsx.snap
+++ b/tests/__snapshots__/placeholders.test.tsx.snap
@@ -241,6 +241,23 @@ Array [
 ]
 `;
 
+exports[`placeholder TextRow renders a TextRow with a lineSpacing of 0 1`] = `
+Array [
+  <div
+    className="text-row"
+    style={
+      Object {
+        "backgroundColor": "rebeccapurple",
+        "height": "1em",
+        "marginTop": 0,
+        "maxHeight": undefined,
+        "width": "100%",
+      }
+    }
+  />,
+]
+`;
+
 exports[`placeholder TextRow renders a TextRow with custom maxHeight and lineSpacing 1`] = `
 Array [
   <div

--- a/tests/placeholders.test.tsx
+++ b/tests/placeholders.test.tsx
@@ -136,6 +136,15 @@ describe('placeholder', () => {
       expect(tree.getElements()).toMatchSnapshot();
     });
 
+    it('renders a TextRow with a lineSpacing of 0', () => {
+      const tree = shallow(
+        <TextRow color="rebeccapurple" lineSpacing={0} />
+      );
+
+      expect(tree.prop('style').marginTop).toBe(0);
+      expect(tree.getElements()).toMatchSnapshot();
+    });
+
     it('renders a TextRow with custom styles and classNames, overriding set maxHeight and lineSpacing', () => {
       const tree = shallow(
         <TextRow


### PR DESCRIPTION
I missed this case when doing the hooks refactor. This uses default value syntax to set the default line spacing. This also means the first row in a TextBlock has a marginTop of 0, which was the behavior before the hooks refactor.