### PR TITLE
Allow children to be a ReactNode instead of ReactElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install --save react-placeholder
 ### Props
 
 ```tsx
-children:              ReactElement | null;
+children:              ReactNode;
 ready:                 boolean;
 delay?:                number;
 firstLaunchOnly?:      boolean;

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -3,7 +3,7 @@ import * as placeholders from './placeholders';
 import { joinClassNames } from './utils';
 
 type CommonProps = {
-  children: React.ReactElement | null;
+  children: React.ReactNode;
   /** pass `true` when the content is ready and `false` when it's loading */
   ready: boolean;
   /** delay in millis to wait when passing from ready to NOT ready */

--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -147,7 +147,14 @@ const ReactPlaceholder: React.FC<Props> = ({
     []
   );
 
-  return ready ? children : getFiller();
+  // Casting - workaround for DefinitelyTyped/react issue with
+  // FunctionComponents returning ReactElement, where they should be able to
+  // return ReactNode. Casting also doesn't introduce another layer in the
+  // component tree like another `<>children</>` workaround does.
+  //
+  // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33006
+  // and https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+  return ready ? children as React.ReactElement : getFiller();
 };
 
 export default ReactPlaceholder;


### PR DESCRIPTION
Since children is just returned by this component, there's no practical reason
that children has to be a single element. We've used multiple children in our
project, and this type definition made an upgrade incompatible.