### PR TITLE
Fix CustomPlaceholder showLoadingAnimation type

### DIFF
--- a/src/ReactPlaceholder.tsx
+++ b/src/ReactPlaceholder.tsx
@@ -29,7 +29,7 @@ type CustomPlaceholderProps = CommonProps & {
   type?: undefined;
   rows?: undefined;
   color?: undefined;
-  showLoadingAnimation?: undefined;
+  showLoadingAnimation?: boolean;
 };
 
 type MediaPlaceholderProps = PlaceholderProps &


### PR DESCRIPTION
Closes [#2520529](https://buildo.kaiten.io/space/32111/card/2520529)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Proposed fix to this issue: https://github.com/buildo/react-placeholder/issues/90

I've pull the repo and it passes a typecheck and test